### PR TITLE
Exclude emsg/emsgroot from doxygen call trees

### DIFF
--- a/utils.cc
+++ b/utils.cc
@@ -101,6 +101,7 @@ vector<string> split(const string& s, char delimiter)
   return splits;                                           
 }
 
+/// @cond EXCLUDE
 /// Displays an error message
 void emsg(string msg)
 {
@@ -118,7 +119,7 @@ void emsgroot(string msg)
 	//MPI_Finalize();
 	exit (EXIT_FAILURE);
 }
-
+/// @endcond
 /// Create a directory if it doesn't already exist
 void ensuredirectory(const string &path) 
 {

--- a/utils.hh
+++ b/utils.hh
@@ -14,8 +14,10 @@
 
 using namespace std;
 
+/// @cond EXCLUDE
 [[ noreturn ]] void emsg(string msg);
 [[ noreturn ]] void emsgroot(string msg);
+/// @endcond
 
 double ran();
 double normal(float mu, float sd);


### PR DESCRIPTION
If the graphs still look too muddled, it's easy enough to extend to ran()

SCRC-385